### PR TITLE
Jg search blogs#39

### DIFF
--- a/TabloidCLI/Repositories/TagRepository.cs
+++ b/TabloidCLI/Repositories/TagRepository.cs
@@ -126,5 +126,40 @@ namespace TabloidCLI
                 }
             }
         }
+
+
+        public SearchResults<Blog> SearchBlogs(string tagName)
+        {
+            using (SqlConnection conn=Connection)
+            {
+                conn.Open();
+                using(SqlCommand cmd =conn.CreateCommand())
+                {
+                    cmd.CommandText = @"SELECT b.id, b.Title, b.Url
+                                        FROM Blog b
+                                        LEFT JOIN BlogTag bt ON b.id = bt.BlogId
+                                        LEFT JOIN Tag t ON t.Id = bt.TagId
+                                        WHERE t.Name LIKE @name";
+                    cmd.Parameters.AddWithValue("@name", $"%{tagName}%");
+                    SqlDataReader reader=cmd.ExecuteReader();
+
+                    SearchResults<Blog> results = new SearchResults<Blog>();
+                    while(reader.Read())
+                    {
+                        Blog blog = new Blog()
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Title = reader.GetString(reader.GetOrdinal("Title")),
+                            Url = reader.GetString(reader.GetOrdinal("Url"))
+                        };
+                        results.Add(blog);
+                    }
+                    reader.Close();
+                    return results;
+                }
+            }
+        }
+
+
     }
 }

--- a/TabloidCLI/UserInterfaceManagers/SearchManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/SearchManager.cs
@@ -16,7 +16,8 @@ namespace TabloidCLI.UserInterfaceManagers
 
         public IUserInterfaceManager Execute()
         {
-            Console.WriteLine("Search Menu");
+            Console.WriteLine();
+            Console.WriteLine("==Search Menu==");
             Console.WriteLine(" 1) Search Blogs");
             Console.WriteLine(" 2) Search Authors");
             Console.WriteLine(" 3) Search Posts");
@@ -28,6 +29,7 @@ namespace TabloidCLI.UserInterfaceManagers
             switch (choice)
             {
                 case "1":
+                    SearchBlogs();
                     return this;
                 case "2":
                     SearchAuthors();
@@ -53,12 +55,34 @@ namespace TabloidCLI.UserInterfaceManagers
 
             if (results.NoResultsFound)
             {
-                Console.WriteLine($"No results for {tagName}");
+                Console.WriteLine();
+                Console.WriteLine($" No Authors found for {tagName}");
             }
             else
             {
                 results.Display();
             }
         }
+
+        private void SearchBlogs()
+        {
+            Console.Write("Tag> ");
+            string tagName = Console.ReadLine();
+
+            SearchResults<Blog> results = _tagRepository.SearchBlogs(tagName);
+            Console.WriteLine();
+
+            if(results.NoResultsFound)
+            {
+                Console.WriteLine(); 
+                Console.WriteLine($" No Blogs found for {tagName}.");
+            }
+            else
+            {
+                results.Display();
+            }
+        }
+
+
     }
 }


### PR DESCRIPTION
Description
Ticket no.39 allows users to select Search Blog from the 'Search by Tag' menu and then type a tag name and view any blogs associated with that tag.

Testing Instructions
Fetch and checkout to the branch called jg-SearchBlogs#39.
Navigate to the Search by Tag menu, Option 6 in the Main Menu.
Select 1) Search Blogs from the Search Menu
Type a tag name that you know exists in your database such as "Nerdy" from the seed data.
The blog(s) associated with that tag should appear.
You will be returned to the Search Menu, Type 1) Search Blog again.
Type a word that you know is not a current tag for blogs such as 'HiggletyPigglety".
Observe a statement saying that no blogs were found for the word you typed.
If both 5 and 8 occur....SUCCESS!

Checklist:
 My code follows the style guidelines of this project
 I have performed a self-review of my code
 I have commented my code, particularly in hard-to-understand areas
 My changes generate no new warnings or errors
 I have added test instructions that prove my fix is e