### PR TITLE
Ticket #35 - Remove Tag from Post

### DIFF
--- a/TabloidCLI/Repositories/PostRepository.cs
+++ b/TabloidCLI/Repositories/PostRepository.cs
@@ -297,8 +297,30 @@ namespace TabloidCLI
                 }
             }
         }
-
-
         // insert tag end
+
+        // delete tag start
+
+        public void DeleteTag(int postId, int tagId)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"DELETE FROM PostTag 
+                                         WHERE PostId = @postid AND 
+                                               TagId = @tagId";
+                    cmd.Parameters.AddWithValue("@postId", postId);
+                    cmd.Parameters.AddWithValue("@tagId", tagId);
+
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
+
+        // delete tag end
+
+
     }
 }

--- a/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
@@ -99,8 +99,29 @@ namespace TabloidCLI.UserInterfaceManagers
 
         private void RemoveTag()
         {
-            throw new NotImplementedException();
+            Post post = _postRepository.Get(_postId);
 
+            Console.WriteLine($"Which tag would you like to remove from {post.Title}?");
+            List<Tag> tags = post.Tags;
+
+            for (int i = 0; i < tags.Count; i++)
+            {
+                Tag tag = tags[i];
+                Console.WriteLine($" {i + 1}) {tag.Name}");
+            }
+            Console.Write("> ");
+
+            string input = Console.ReadLine();
+            try
+            {
+                int choice = int.Parse(input);
+                Tag tag = tags[choice - 1];
+                _postRepository.DeleteTag(post.Id, tag.Id);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Invalid Selection. Won't remove any tags.");
+            }
         }
     }
 }


### PR DESCRIPTION
# Description

This PR is for [Ticket #35](https://trello.com/c/SDwjlEkU), which should allow the user to select Remove Tag from the Post Details menu. Once there, the user should be able given a list of tags to choose from and be able to choose one to remove from the selected post. This has been tested in the CLI and appears to correctly remove, upon the user's request, the selected tag from their post.

# Testing Instructions

1. Git fetch --all
2. Git checkout ac-removeTags to switch to my branch.
If you don't see the most recent version of the files, try git pull origin ac-removeTags.
3. Execute TabloidCli from inside of Visual Studio
4. Select option 4, Post Management, from the Main Menu.
5. Select option 2, Post Details, from the Post Menu.
6. You will be prompted to select a post. To proceed, please do so.
7. Select option 3, Remove Tag, from the Details Menu.
8. You will be asked which tag you would like to remove. Choose one to remove from the post.
9. From the menu that you're taken to after your selection has been made, select option 1, View, and observe the changes made to the post. If the tag was removed, this feature functions as it should.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
